### PR TITLE
Ensures that 'Stukken' menu item also respects https requests.

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -127,7 +127,7 @@ function emit_menu() { global $page; ?>
 					<li><a href="<?php echo auri('smoelen') ?>">Smoelenboek</a></li>
 					<li><a href="<?php echo auri('wiki') ?>">Wiki</a></li>
 					<li><a href="<?php echo auri('forum') ?>">Forum</a></li>
-					<li><a href="http://karpenoktem.nl/groups/leden">Stukken</a></li>
+					<li><a href="<?php echo auri('groups/leden') ?>">Stukken</a></li>
 				</ul></li>
 				<li><a href="<?php echo auri('merchandise') ?>"
 						>Merchandise</a></li>


### PR DESCRIPTION
Aangezien in de repo geen site-config staat (in het bijzonder de waardes van $cfg['auri'] en $cfg['curi']), heb ik hier maar gegokt dat de functie 'auri' de juiste url returnt.

Use case: ingelogde sessie onder www.karpenoktem.nl is geen ingelogde sessie onder karpenoktem.nl
