### PR TITLE
Don't use hardcoded URLs

### DIFF
--- a/actions/links.php
+++ b/actions/links.php
@@ -17,7 +17,7 @@ voor de nieuwe foto's op
 
 <p>Maar vergeet niet</p>
 <ul>
-<li><a href="https://karpenoktem.nl/wiki">onze wiki</a>,</li>
+<li><a href="<?php echo auri('wiki') ?>">onze wiki</a>,</li>
 <li><a href="<?php echo auri('forum') ?>">ons forum</a> en</li>
 <li>de <a href="<?php echo auri('zusjes') ?>">zusjes</a>.</li>
 </ul>

--- a/actions/media.php
+++ b/actions/media.php
@@ -1,10 +1,10 @@
 <?php set_title('Media');
       default_header(); ?>
 <ul>
-	<li>Foto's van <a href="http://karpenoktem.nl/fotos/"
+	<li>Foto's van <a href="/fotos/"
                 >Karpe Noktem</a></li>
 	<li>Foto's van <a
-	href="http://karpenoktem.nl/fotos/index.php?album=pdn"
+	href="/fotos/index.php?album=pdn"
                 >Pluk de Nacht weekend</a></li>
 	<li>2009: Een reportage van <a
 	href="http://www.youtube.com/watch?v=NLOT1TkZTf4"

--- a/actions/media.php
+++ b/actions/media.php
@@ -1,10 +1,10 @@
 <?php set_title('Media');
       default_header(); ?>
 <ul>
-	<li>Foto's van <a href="/fotos/"
+	<li>Foto's van <a href="<?php echo euri('fotos') ?>"
                 >Karpe Noktem</a></li>
 	<li>Foto's van <a
-	href="/fotos/index.php?album=pdn"
+	href="<?php echo euri('fotos-pdn') ?>"
                 >Pluk de Nacht weekend</a></li>
 	<li>2009: Een reportage van <a
 	href="http://www.youtube.com/watch?v=NLOT1TkZTf4"

--- a/config.default.php
+++ b/config.default.php
@@ -1,15 +1,19 @@
 <?php
 
-$cfg = array('interested-subscribe-uri' => '/'.
+$base_url = 'https://karpenoktem.nl/';
+
+$cfg = array('interested-subscribe-uri' => $base_url.
 		'mailman/subscribe/geinteresseerden');
 
 $cfg['links'] = array();
 
-$base_url = 'https://karpenoktem.nl/';
-$cfg['links']['wiki'] = $base_url.'wiki';
+$cfg['links']['wiki'] = $base_url.'wiki/Hoofdpagina';
 $cfg['links']['forum'] = $base_url.'forum';
 $cfg['links']['smoelen'] = $base_url.'smoelen';
 $cfg['links']['stukken'] = $base_url.'groups/leden';
+$cfg['links']['fotos'] = $base_url.'fotos/';
+$cfg['links']['fotos-pdn'] = $base_url.'fotos/index.php?album=pdn';
+
 unset($base_url);
 
 if(is_file('config.php'))

--- a/config.default.php
+++ b/config.default.php
@@ -1,6 +1,6 @@
 <?php
 
-$cfg = array('interested-subscribe-uri' => 'https://karpenoktem.nl/'.
+$cfg = array('interested-subscribe-uri' => '/'.
 		'mailman/subscribe/geinteresseerden');
 
 if(is_file('config.php'))

--- a/lib/common.php
+++ b/lib/common.php
@@ -119,8 +119,8 @@ function emit_menu() { global $page; ?>
 				</ul></li>
 				<li><a href="<?php echo auri('media') ?>">Fotos/videos</a>
 				<ul>
-					<li><a href="https://karpenoktem.nl/fotos/">Fotogalerij</a></li>
-					<li><a href="https://karpenoktem.nl/fotos/index.php?album=pdn">Pluk de Nacht</a></li>
+					<li><a href="<?php echo auri('fotos') ?>">Fotogalerij</a></li>
+					<li><a href="<?php echo auri('fotos/index.php?album=pdn') ?>">Pluk de Nacht</a></li>
 				</ul></li>
                                 <li><a href="<?php echo auri('smoelen') ?>">Leden</a>
 				<ul>

--- a/lib/common.php
+++ b/lib/common.php
@@ -8,12 +8,14 @@ $page = array('bg' => 'rest',
                           'unsafe-email' => false,
 			  'bare' => false);
 
+/* external URIs */
 function euri($what) {
         global $cfg;
         assert(isset($cfg['links'][$what]));
         return $cfg['links'][$what];
 }
 
+/* action URIs */
 function auri($action, $qs='', $an='') {
 	global $cfg;
         $r = (isset($_SERVER['HTTPS']) ? 'https://' : 'http://')
@@ -23,6 +25,7 @@ function auri($action, $qs='', $an='') {
 	return $r;
 }
 
+/* content URIs */
 function curi($content) {
 	global $cfg;
         return (isset($_SERVER['HTTPS']) ? 'https://' : 'http://')
@@ -125,8 +128,8 @@ function emit_menu() { global $page; ?>
 				</ul></li>
 				<li><a href="<?php echo auri('media') ?>">Fotos/videos</a>
 				<ul>
-					<li><a href="<?php echo auri('fotos') ?>">Fotogalerij</a></li>
-					<li><a href="<?php echo auri('fotos/index.php?album=pdn') ?>">Pluk de Nacht</a></li>
+					<li><a href="<?php echo euri('fotos') ?>">Fotogalerij</a></li>
+					<li><a href="<?php echo euri('fotos-pdn') ?>">Pluk de Nacht</a></li>
 				</ul></li>
                                 <li><a href="<?php echo euri('smoelen') ?>">Leden</a>
 				<ul>


### PR DESCRIPTION
Ik kan genoeg redenen bedenken waarom dit handiger is. Voor mij is het vooral handiger dat links gewoon blijven werken op een lokale installatie en niet naar karpenoktem.nl verwijzen. Verder helpt het met andere wijzigingen als toen we van http naar https gingen.
