### PR TITLE
GitHub HTTPS url nitpick

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ uitgevoerd door *Mirjam Hengeveld* en *Bas Westerbaan* in December 2007.
 
 Vanaf het begin is deze website bedoeld als een tussenoplossing.  Het plan is
 het algemene publieke deel van de website op termijn ook op te nemen in de
-`algemene infrastructuur <http://github.com/karpenoktem/kninfra>`_.
+`algemene infrastructuur <https://github.com/karpenoktem/kninfra>`_.
 
 De website wordt onderhouden door de Webcie_.
 


### PR DESCRIPTION
GitHub gebruikt https overal. Het is iets netter als de link dan ook gewijzigd wordt in een https link.
